### PR TITLE
Cast function to load project config from toml

### DIFF
--- a/src/settings.py
+++ b/src/settings.py
@@ -1,10 +1,13 @@
+from pathlib import Path
+
 import tomllib
 from decouple import config
 
 DATABASE_URL = config("DATABASE_URL")
 OPENAI_API_KEY = config("OPENAI_API_KEY")
 VERBOSE_LLM = config("VERBOSE_LLM", default=False, cast=bool)
-
-PROJECT_CONFIG = {}
-with open(config("PROJECT_CONFIG"), "rb") as f:
-    PROJECT_CONFIG = tomllib.load(f)
+PROJECT_CONFIG = config(
+    "PROJECT_CONFIG",
+    cast=lambda filename: tomllib.loads(Path(filename).read_text()),
+    default={},
+)


### PR DESCRIPTION
Small refactor on `PROJECT_CONFIG` using decouple's cast attribute  

https://github.com/HBNetwork/python-decouple#understanding-the-cast-argument