### PR TITLE
Refactor chat memory usage

### DIFF
--- a/src/llm/memory.py
+++ b/src/llm/memory.py
@@ -36,7 +36,7 @@ class CustomPostgresChatMessageHistory(PostgresChatMessageHistory):
         session.query(Chat).where(Chat.uuid == self.session_id).update({Chat.tags: tags})
         session.commit()
 
-    def add_message(self, message: BaseMessage) -> ChatMessages:
+    def add_message(self, message: BaseMessage) -> None:
         """Append the message to the record in PostgreSQL"""
         message = ChatMessages(session_id=self.session_id, message=_message_to_dict(message))
         if self.parent_session_id:

--- a/src/llm/memory.py
+++ b/src/llm/memory.py
@@ -1,9 +1,7 @@
 
 from langchain.memory import PostgresChatMessageHistory
 from langchain.schema.messages import (
-    AIMessage,
     BaseMessage,
-    HumanMessage,
     _message_to_dict,
 )
 from models import Chat, ChatMessages


### PR DESCRIPTION
- Remove manually interactions with chat history to save and load messages on prompt
- Respects abstraction's contract on `add_message`, this method should return `None` instead of  `ChatMessages` instance.

fixed: https://github.com/talkdai/dialog/issues/34
related: #21 