### PR TITLE
add simple answer time logging

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -10,6 +10,14 @@ from models.db import engine, session
 from pydantic import BaseModel
 from sqlalchemy import text
 
+import datetime
+import logging
+from settings import LOGGING_LEVEL
+logging.basicConfig(
+    level=LOGGING_LEVEL,
+    format="%(asctime)s - %(levelname)s - %(message)s"
+)
+
 app = FastAPI(
     title="Dialog API",
     description="Humanized Conversation API (using LLM)",
@@ -54,8 +62,10 @@ async def post_message(chat_id: str, message: Chat):
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Chat ID not found",
         )
-
+    start_time = datetime.datetime.now()
     ai_message = process_user_intent(chat_id, message.message)
+    duration = datetime.datetime.now() - start_time
+    logging.info(f"Request processing time for chat_id {chat_id}: {duration}")
     return {"message": ai_message["text"]}
 
 @app.get("/chat/{chat_id}")

--- a/src/settings.py
+++ b/src/settings.py
@@ -3,6 +3,8 @@ from pathlib import Path
 import tomllib
 from decouple import config
 
+LOGGING_LEVEL = config("LOGGING_LEVEL", default="INFO")
+
 DATABASE_URL = config("DATABASE_URL")
 OPENAI_API_KEY = config("OPENAI_API_KEY")
 VERBOSE_LLM = config("VERBOSE_LLM", default=False, cast=bool)


### PR DESCRIPTION
An example from terminal would be:
```
INFO:     Application startup complete.
2023-11-25 11:39:48,707 - INFO - HTTP Request: POST https://api.openai.com/v1/embeddings "HTTP/1.1 200 OK"


> Entering new LLMChain chain...
Prompt after formatting:
...
Human: até quando posso cancelar minha passagem?
2023-11-25 11:40:19,401 - INFO - HTTP Request: POST https://api.openai.com/v1/chat/completions "HTTP/1.1 200 OK"

> Finished chain.
2023-11-25 11:40:19,434 - INFO - Request processing time for chat_id af407e24aa69405eac1c7e9f0209006e: 0:00:31.507719
```

fixed: #53