### PR TITLE
Pinned python in the versions >=3.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 homepage = "https://github.com/talkdai/dialog"
 
 [tool.poetry.dependencies]
-python = "^3.9,<3.12"
+python = ">=3.11,<3.12"
 fastapi = "^0.104.1"
 sqlalchemy = "^2.0.23"
 langchain = "^0.0.333"


### PR DESCRIPTION
talkdai/dialog needs parse toml files with tomllib, and tomllib was introduced in standard python in the 3.11 version.
dockerfile already use python 3.11 and my thoughts believe that haven't problem change pyproject.toml.