### PR TITLE
Dont run docker build job on forks

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,11 +9,11 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: github.repository == 'talkdai/dialog'
     environment: build
     defaults:
       run:
         shell: bash
-
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
The docker build and push to registry only make sense on main repository.