### PR TITLE
Fix and tweak db service healthcheck

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,11 +13,10 @@ services:
        - ./data/db:/var/lib/postgresql/data
        - ./etc/db-ext-vector.sql:/docker-entrypoint-initdb.d/db-ext-vector.sql
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready", "-d", "talkdai", "-U", "talkdai"]
-      interval: 30s
-      timeout: 60s
+      test: ["CMD", "pg_isready", "-d", "talkdai", "-U", "talkdai"]
+      interval: 10s
+      timeout: 5s
       retries: 5
-      start_period: 80s
   dialog:
     build:
       context: .


### PR DESCRIPTION
fix #128 

The healthcheck test  type `CMD-SHELL` expect the whole command to be in a single string