### PR TITLE
Fix install extension pgvector via migration

### DIFF
--- a/src/dialog/migrations/versions/b3ca30115351_.py
+++ b/src/dialog/migrations/versions/b3ca30115351_.py
@@ -14,7 +14,7 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
-    op.execute("CREATE EXTENSION IF NOT EXISTS pgvector;")
+    op.execute("CREATE EXTENSION IF NOT EXISTS vector;")
     op.create_table(
         "contents",
         sa.Column("id", sa.Integer(), nullable=False),


### PR DESCRIPTION
The correct name of the pgvector's extension inside postgres is only `vector`

fixes #131 