### PR TITLE
Fix default fallback behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ To load the knowledge base into the database, make sure the database is up and t
 
 The `[prompt.header]`, `[prompt.suggested]`, and `[fallback.prompt]` fields are mandatory fields used for processing the conversation and connecting to the LLM.
 
-The `[fallback.prompt]` field is used when the LLM does not find a compatible embedding on the database, without it, it would hallucinate on possible answers for questions outside of the scope of the embeddings.
+The `[fallback.prompt]` field is used when the LLM does not find a compatible embedding on the database, without it, it could hallucinate on possible answers for questions outside of the scope of the embeddings (by default, if you don't provide one, then a default value `"I'm sorry, I don't understand that."` is used).
 
 It is also possible to add information to the prompt for subcategories and choose some optional llm parameters like temperature (defaults to 0.2) or model_name, see below for an example of a complete configuration:
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ To load the knowledge base into the database, make sure the database is up and t
 
 The `[prompt.header]`, `[prompt.suggested]`, and `[fallback.prompt]` fields are mandatory fields used for processing the conversation and connecting to the LLM.
 
-The `[fallback.prompt]` field is used when the LLM does not find a compatible embedding on the database, without it, it could hallucinate on possible answers for questions outside of the scope of the embeddings (by default, if you don't provide one, then a default value `"I'm sorry, I don't understand that."` is used).
+The `[fallback.prompt]` field is used when the LLM does not find a compatible embedding on the database, without it, it could hallucinate on possible answers for questions outside of the scope of the embeddings. If not defined, the prompt with zero documents and user's question will still pass through the llm and hence the answer will depend of your prompt instructions. An example of default fallback would be `"I'm sorry, I don't understand that."`.
 
 It is also possible to add information to the prompt for subcategories and choose some optional llm parameters like temperature (defaults to 0.2) or model_name, see below for an example of a complete configuration:
 

--- a/src/dialog/llm/abstract_llm.py
+++ b/src/dialog/llm/abstract_llm.py
@@ -19,6 +19,7 @@ class AbstractLLM:
 
         self.config = config
         self.prompt = None
+        self.fallback = None
         self.session_id = None
         if session_id:
             self.session_id = session_id if dataset is None else f"{dataset}_{session_id}" 
@@ -79,8 +80,11 @@ class AbstractLLM:
         """
         processed_input = self.preprocess(input)
         self.generate_prompt(processed_input)
-        output = self.llm({
-            "user_message": processed_input,
-        })
+        if self.fallback:
+            output = {"text": self.fallback}
+        else:
+            output = self.llm({
+                "user_message": processed_input,
+            })
         processed_output = self.postprocess(output)
         return processed_output

--- a/src/dialog/llm/default.py
+++ b/src/dialog/llm/default.py
@@ -14,7 +14,7 @@ from dialog.llm.abstract_llm import AbstractLLM
 from dialog.llm.embeddings import get_most_relevant_contents_from_message
 from dialog.llm.memory import generate_memory_instance
 from dialog.settings import (OPENAI_API_KEY, VERBOSE_LLM, LLM_RELEVANT_CONTENTS,
-                             LLM_TEMPERATURE, LLM_MEMORY_SIZE)
+                             LLM_TEMPERATURE, LLM_MEMORY_SIZE, FALLBACK_PROMPT_TEMPLATE)
 
 
 class DialogLLM(AbstractLLM):
@@ -30,7 +30,6 @@ class DialogLLM(AbstractLLM):
     def generate_prompt(self, input):
         relevant_contents = get_most_relevant_contents_from_message(input, top=LLM_RELEVANT_CONTENTS, dataset=self.dataset)
         prompt_config = self.config.get("prompt")
-        fallback = self.config.get("fallback").get("prompt")
         header = prompt_config.get("header")
         suggested = prompt_config.get("suggested")
         messages = []
@@ -43,7 +42,7 @@ class DialogLLM(AbstractLLM):
             messages.append(MessagesPlaceholder(variable_name="chat_history", optional=True))
             messages.append(HumanMessagePromptTemplate.from_template("{user_message}"))
         else:
-            messages.append(SystemMessagePromptTemplate.from_template(fallback))
+            messages.append(SystemMessagePromptTemplate.from_template(FALLBACK_PROMPT_TEMPLATE))
             messages.append(HumanMessagePromptTemplate.from_template("{user_message}"))
             
         self.prompt = ChatPromptTemplate.from_messages(messages)

--- a/src/dialog/llm/default.py
+++ b/src/dialog/llm/default.py
@@ -41,13 +41,11 @@ class DialogLLM(AbstractLLM):
             messages.append(SystemMessagePromptTemplate.from_template(f"{suggested}. {context}"))
             messages.append(MessagesPlaceholder(variable_name="chat_history", optional=True))
             messages.append(HumanMessagePromptTemplate.from_template("{user_message}"))
+            self.prompt = ChatPromptTemplate.from_messages(messages)
+            if VERBOSE_LLM:
+                logging.info(f"Verbose LLM prompt: {self.prompt.pretty_print()}")
         else:
-            messages.append(SystemMessagePromptTemplate.from_template(FALLBACK_PROMPT_TEMPLATE))
-            messages.append(HumanMessagePromptTemplate.from_template("{user_message}"))
-            
-        self.prompt = ChatPromptTemplate.from_messages(messages)
-        if VERBOSE_LLM:
-            logging.info(f"Verbose LLM prompt: {self.prompt.pretty_print()}")
+            self.fallback = FALLBACK_PROMPT_TEMPLATE
 
     @property
     def llm(self) -> LLMChain:

--- a/src/dialog/llm/default.py
+++ b/src/dialog/llm/default.py
@@ -33,18 +33,18 @@ class DialogLLM(AbstractLLM):
         header = prompt_config.get("header")
         suggested = prompt_config.get("suggested")
         messages = []
-        if len(relevant_contents) > 0:
-            context = "Context: \n".join(
-                [f"{c.question}\n{c.content}\n" for c in relevant_contents]
-            )
-            messages.append(SystemMessagePromptTemplate.from_template(header))
-            messages.append(SystemMessagePromptTemplate.from_template(f"{suggested}. {context}"))
-            messages.append(MessagesPlaceholder(variable_name="chat_history", optional=True))
-            messages.append(HumanMessagePromptTemplate.from_template("{user_message}"))
-            self.prompt = ChatPromptTemplate.from_messages(messages)
-            if VERBOSE_LLM:
-                logging.info(f"Verbose LLM prompt: {self.prompt.pretty_print()}")
-        else:
+        context = "Context: \n".join(
+            [f"{c.question}\n{c.content}\n" for c in relevant_contents]
+        )
+        messages.append(SystemMessagePromptTemplate.from_template(header))
+        messages.append(SystemMessagePromptTemplate.from_template(f"{suggested}. {context}"))
+        messages.append(MessagesPlaceholder(variable_name="chat_history", optional=True))
+        messages.append(HumanMessagePromptTemplate.from_template("{user_message}"))
+        self.prompt = ChatPromptTemplate.from_messages(messages)
+        if VERBOSE_LLM:
+            logging.info(f"{len(relevant_contents)} Documents retrieved from knowledge base")
+            logging.info(f"Verbose LLM prompt: {self.prompt.pretty_print()}")
+        if len(relevant_contents) == 0:
             self.fallback = FALLBACK_PROMPT_TEMPLATE
 
     @property

--- a/src/dialog/settings.py
+++ b/src/dialog/settings.py
@@ -15,13 +15,14 @@ PROJECT_CONFIG = config(
 )
 PLUGINS = config("PLUGINS", cast=Csv(), default=None)
 
-# Used to load custom LLM classes
+# Langchain and LLM parameters and settings
 LLM_CLASS = config("LLM_CLASS", default=None)
 LLM_TEMPERATURE = config("LLM_TEMPERATURE", default=0.2, cast=float)
 LLM_RELEVANT_CONTENTS = config("LLM_RELEVANT_CONTENTS", default=1, cast=int)
 LLM_MEMORY_SIZE = config("LLM_MEMORY_SIZE", default=5, cast=int)
 STATIC_FILE_LOCATION = config("STATIC_FILE_LOCATION", "/app/static")
 COSINE_SIMILARITY_THRESHOLD = config("CONSINE_SIMILARITY_THRESHOLD", default=0.2, cast=float)
+FALLBACK_PROMPT_TEMPLATE = PROJECT_CONFIG.get("fallback", {"prompt": "I'm sorry, I don't understand that."}).get("prompt")
 
 # Cors
 CORS_ALLOW_ORIGINS = config("CORS_ALLOW_ORIGINS", cast=Csv(), default="*")

--- a/src/dialog/settings.py
+++ b/src/dialog/settings.py
@@ -22,7 +22,7 @@ LLM_RELEVANT_CONTENTS = config("LLM_RELEVANT_CONTENTS", default=1, cast=int)
 LLM_MEMORY_SIZE = config("LLM_MEMORY_SIZE", default=5, cast=int)
 STATIC_FILE_LOCATION = config("STATIC_FILE_LOCATION", "/app/static")
 COSINE_SIMILARITY_THRESHOLD = config("CONSINE_SIMILARITY_THRESHOLD", default=0.2, cast=float)
-FALLBACK_PROMPT_TEMPLATE = PROJECT_CONFIG.get("fallback", {"prompt": "I'm sorry, I don't understand that."}).get("prompt")
+FALLBACK_PROMPT_TEMPLATE = PROJECT_CONFIG.get("fallback", {"prompt": None}).get("prompt")
 
 # Cors
 CORS_ALLOW_ORIGINS = config("CORS_ALLOW_ORIGINS", cast=Csv(), default="*")


### PR DESCRIPTION
Fixes #117 , keeping the default fallback behavior in case of no embeddings found from the retriever. The objective here is to answer a default fallback (if defined in toml) template when no documents are returned in the retrieval step. 

edit: now, if no fallback is defined, the prompt still passes through GPT, hence delegating the answer to gpt even with no documents retrieved 